### PR TITLE
fix index out of range error by setting length check to 3 instead of 2

### DIFF
--- a/protein.py
+++ b/protein.py
@@ -529,7 +529,7 @@ class Cholesterol(Compound):
        """
        cho_count = 0
        for line in open(self.pdb, "r"):
-           if len(line.split()) > 2:
+           if len(line.split()) > 3:
                if line.split()[3] in ["CHO", "CLR"]:
                    cho_count += 1
        return cho_count / 74 #Each CHO has 74 atoms


### PR DESCRIPTION
```
    def count_cho(self):
       """
       Count and set the number of cho in the pdb
       """
       cho_count = 0
       for line in open(self.pdb, "r"):
           print(line.split())
           if len(line.split()) > 2:
               if line.split()[3] in ["CHO", "CLR"]:
                   cho_count += 1
       return cho_count / 74 #Each CHO has 74 atoms
```

length of line should be > 3 (indexing starts at 0)